### PR TITLE
redefine upstart service restart

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -8,11 +8,11 @@ This recipe call config recipe and setup a chef-rundeck service that host all br
 #>
 =end
 
-
 include_recipe 'rundeck-bridge::config'
 
 # Start chef-rundeck service
 service 'chef-rundeck' do
-  provider Chef::Provider::Service::Upstart
-  action [:enable, :start]
+  provider        Chef::Provider::Service::Upstart
+  restart_command '/sbin/stop chef-rundeck && /sbin/start chef-rundeck'
+  action          [:enable, :start]
 end


### PR DESCRIPTION
The only way to make upstart reread the configuration file is to stop and start the service.
