### PR TITLE
Add sinatra beta version

### DIFF
--- a/.kitchen.ec2.yml
+++ b/.kitchen.ec2.yml
@@ -14,6 +14,7 @@ driver:
   name: ec2
   instance_type: t2.micro
   associate_public_ip: true
+  iam_profile_name: test-kitchen
   region: <%= ENV['AWS_REGION'] || 'us-west-2' %>
   subnet_filter:
     tag:   'Name'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- 2.1
+- 2.2.2
 deploy:
   edge: true
   provider: chef-supermarket

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -17,6 +17,14 @@ directory node['rundeck_bridge']['home'] do
   recursive true
 end
 
+# Install sinatra beta version
+# Required to avoid the following issue for Chef >= 12.14.60
+# https://github.com/Webtrends/rundeck/issues/100
+chef_gem 'sinatra' do
+  version '>= 2.0.0.beta2'
+  only_if { Chef::Version.new(Chef::VERSION) >= Chef::Version.new('12.14.60') }
+end
+
 # Install chef-rundeck in chef as it requires chef
 chef_gem 'chef-rundeck' do
   compile_time false


### PR DESCRIPTION
For Chef versions >= 12.14.60, the cookbook fails to converge because of a dependency issue which has been fixed in sinatra 2.0.0.beta2.

For more information see https://github.com/Webtrends/rundeck/issues/100